### PR TITLE
View more drinks functionality

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "react-tech-test",
       "version": "0.0.0",
       "dependencies": {
+        "@mui/base": "^5.0.0-beta.36",
         "axios": "^1.6.7",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -322,6 +323,17 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.23.9",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.9.tgz",
+      "integrity": "sha512-0CX6F+BI2s9dkUqr08KFrAIZgNFj75rdBU/DjCyYLIaV/quFjkk6T+EJ2LkZHyZTbEV4L5p97mNkUsHl2wLFAw==",
+      "dependencies": {
+        "regenerator-runtime": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -812,6 +824,40 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@floating-ui/core": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.0.tgz",
+      "integrity": "sha512-PcF++MykgmTj3CIyOQbKA/hDzOAiqI3mhuoN44WRCopIs1sgoDoU4oty4Jtqaj/y3oDU6fnVSm4QG0a3t5i0+g==",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.1"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.1.tgz",
+      "integrity": "sha512-iA8qE43/H5iGozC3W0YSnVSW42Vh522yyM1gj+BqRwVsTNOyr231PsXDaV04yT39PsO0QL2QpbI/M0ZaLUQgRQ==",
+      "dependencies": {
+        "@floating-ui/core": "^1.6.0",
+        "@floating-ui/utils": "^0.2.1"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.8.tgz",
+      "integrity": "sha512-HOdqOt3R3OGeTKidaLvJKcgg75S6tibQ3Tif4eyd91QnIJWr0NLvoXFpJA/j8HqkFSL68GDca9AuyWEHlhyClw==",
+      "dependencies": {
+        "@floating-ui/dom": "^1.6.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.1.tgz",
+      "integrity": "sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q=="
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.14",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
@@ -893,6 +939,82 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@mui/base": {
+      "version": "5.0.0-beta.36",
+      "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-beta.36.tgz",
+      "integrity": "sha512-6A8fYiXgjqTO6pgj31Hc8wm1M3rFYCxDRh09dBVk0L0W4cb2lnurRJa3cAyic6hHY+we1S58OdGYRbKmOsDpGQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.23.9",
+        "@floating-ui/react-dom": "^2.0.8",
+        "@mui/types": "^7.2.13",
+        "@mui/utils": "^5.15.9",
+        "@popperjs/core": "^2.11.8",
+        "clsx": "^2.1.0",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0",
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/types": {
+      "version": "7.2.13",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.13.tgz",
+      "integrity": "sha512-qP9OgacN62s+l8rdDhSFRe05HWtLLJ5TGclC9I1+tQngbssu0m2dmFZs+Px53AcOs9fD7TbYd4gc9AXzVqO/+g==",
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/utils": {
+      "version": "5.15.9",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.15.9.tgz",
+      "integrity": "sha512-yDYfr61bCYUz1QtwvpqYy/3687Z8/nS4zv7lv/ih/6ZFGMl1iolEvxRmR84v2lOYxlds+kq1IVYbXxDKh8Z9sg==",
+      "dependencies": {
+        "@babel/runtime": "^7.23.9",
+        "@types/prop-types": "^15.7.11",
+        "prop-types": "^15.8.1",
+        "react-is": "^18.2.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0",
+        "react": "^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/utils/node_modules/react-is": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -926,6 +1048,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
       }
     },
     "node_modules/@remix-run/router": {
@@ -1155,14 +1286,13 @@
     "node_modules/@types/prop-types": {
       "version": "15.7.11",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.11.tgz",
-      "integrity": "sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng==",
-      "dev": true
+      "integrity": "sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng=="
     },
     "node_modules/@types/react": {
       "version": "18.2.55",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.55.tgz",
       "integrity": "sha512-Y2Tz5P4yz23brwm2d7jNon39qoAtMMmalOQv6+fEFt1mT+FcM3D841wDpoUvFXhaYenuROCy3FZYqdTjM7qVyA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -1182,7 +1312,7 @@
       "version": "0.16.8",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.8.tgz",
       "integrity": "sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@ungap/structured-clone": {
       "version": "1.2.0",
@@ -1524,6 +1654,14 @@
         "node": ">=4"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.0.tgz",
+      "integrity": "sha512-m3iNNWpd9rl3jvvcBnu70ylMdrXt8Vlq4HYadnU5fwcOtvkSQWPmj7amUcDT2qYI7risszBjI5AUIUox9D16pg==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -1580,7 +1718,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -3121,7 +3259,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3371,7 +3508,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -3438,8 +3574,7 @@
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/react-refresh": {
       "version": "0.14.0",
@@ -3500,6 +3635,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.1",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@mui/base": "^5.0.0-beta.36",
     "axios": "^1.6.7",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/App.css
+++ b/src/App.css
@@ -30,6 +30,11 @@
   background-color: #f5f5f5;
   border-radius: 30px;
   height: 100%;
+  border: 1px solid transparent;
+}
+
+.home_drinkListItem:hover {
+  border: 1px solid rgba(255, 166, 0, 0.679);
 }
 
 .home_drinkDisplayWrapper {

--- a/src/App.css
+++ b/src/App.css
@@ -129,3 +129,23 @@
   cursor: pointer;
 
 }
+
+.viewMore_Container {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  font-variant-numeric: tabular-nums;
+}
+
+.viewMore_displayWrapper {
+  display: flex;
+}
+
+.viewMore_optionsWrapper {
+  position: absolute;
+  top: 0;
+  left: 0;
+  display: flex;
+  flex-direction: column;
+}

--- a/src/App.css
+++ b/src/App.css
@@ -61,11 +61,6 @@
   object-fit: contain;
 }
 
-.home-chevronDown {
-  width: 20px;
-  height: 20px;
-}
-
 .drink_drinkContainer {
   display: flex;
   flex-direction: column;
@@ -130,7 +125,7 @@
 
 }
 
-.viewMore_Container {
+.view-more-container {
   position: relative;
   display: flex;
   flex-direction: column;
@@ -138,11 +133,16 @@
   font-variant-numeric: tabular-nums;
 }
 
-.viewMore_displayWrapper {
+.view-more-display-wrapper {
   display: flex;
 }
 
-.viewMore_optionsWrapper {
+.view-more-chevron-down {
+  width: 20px;
+  height: 20px;
+}
+
+.view-more-options-wrapper {
   position: absolute;
   top: 0;
   left: 0;

--- a/src/App.css
+++ b/src/App.css
@@ -80,6 +80,7 @@
   right: 50px;
   display: flex;
   align-items: center;
+  cursor: pointer;
 }
 
 .home-dropdown-text-span{
@@ -188,6 +189,8 @@
   padding-left: 8px;
   padding-bottom: 5px;
   text-align: left;
+  cursor: pointer;
+
 }
 
 .view-more-options-button:hover {
@@ -200,6 +203,7 @@
 .view-more-chevron-down {
   width: 20px;
   height: 20px;
+  cursor: pointer;
 }
 
 .view-more-options-wrapper {
@@ -214,6 +218,5 @@
   border-radius: 5px;
   padding: 5px 0;
   background-color: #f5f5f5;
-
-
+  cursor: pointer;
 }

--- a/src/App.css
+++ b/src/App.css
@@ -61,6 +61,11 @@
   object-fit: contain;
 }
 
+.home-chevronDown {
+  width: 20px;
+  height: 20px;
+}
+
 .drink_drinkContainer {
   display: flex;
   flex-direction: column;

--- a/src/App.css
+++ b/src/App.css
@@ -1,4 +1,5 @@
 .home_Container {
+  position: relative;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -7,6 +8,14 @@
 
 .home_Title {
   font-size: 48px;
+  margin-bottom: 20px;
+}
+
+.home-tagline {
+  font-size: 28px;
+  font-weight: 200;
+  margin-bottom: 20px;
+
 }
 
 .home_drinksContainer {
@@ -20,7 +29,6 @@
 .home_drinkListItem {
   background-color: #f5f5f5;
   border-radius: 30px;
-  border: 1px solid orange;
   height: 100%;
 }
 
@@ -59,6 +67,18 @@
 .home_drinkImage {
   height: 250px;
   object-fit: contain;
+}
+
+.home-dropdown-container {
+  position: absolute;
+  top: 140px;
+  right: 50px;
+  display: flex;
+  align-items: center;
+}
+
+.home-dropdown-text-span{
+  margin-left: 5px;
 }
 
 .drink_drinkContainer {
@@ -135,8 +155,43 @@
 
 .view-more-display-wrapper {
   display: flex;
+  padding: 5px;
+  align-items: center;
+  border: 1px solid rgba(0, 0, 0, 0.304);
+  border-radius: 5px;
+  background-color: #f5f5f5
+
 }
 
+.view-more-display-number {
+  margin-right: 10px;
+  padding-left: 5px;
+}
+
+
+.view-more-dropdown-button {
+  border: none;
+  border-radius: 10px;
+  background-color: #f5f5f5 
+}
+
+.view-more-options-button {
+  font-size: 16px;
+  border: none;
+  border-radius: 5px;
+  background-color: #f5f5f5;
+  padding-left: 8px;
+  padding-bottom: 5px;
+  text-align: left;
+}
+
+.view-more-options-button:hover {
+  background-color: rgba(0, 0, 0, 0.304);
+}
+
+.view-more-options-button:first-child{
+  padding: none;
+}
 .view-more-chevron-down {
   width: 20px;
   height: 20px;
@@ -144,8 +199,16 @@
 
 .view-more-options-wrapper {
   position: absolute;
-  top: 0;
-  left: 0;
+  top: 40px;
+  left: 40px;
   display: flex;
+  width: 100%;
   flex-direction: column;
+  font-weight: 300;
+  border: 1px solid rgba(0, 0, 0, 0.304);
+  border-radius: 5px;
+  padding: 5px 0;
+  background-color: #f5f5f5;
+
+
 }

--- a/src/components/NavButton/index.jsx
+++ b/src/components/NavButton/index.jsx
@@ -3,7 +3,6 @@ function NavButton() {
   const navigate = useNavigate();
 
   const navigateToHome = () => {
-    console.log('navigating to home');
     navigate('/');
   };
   return (

--- a/src/components/ViewMoreDropDown/index.jsx
+++ b/src/components/ViewMoreDropDown/index.jsx
@@ -4,8 +4,8 @@ function ViewMoreDropDown(props) {
   return (
     <div className='view-more-container'>
       <div className='view-more-display-wrapper'>
-        <div>{numberOfDrinks}</div>
-        <button onClick={() => handleShowDropDown()}>
+        <div className={'view-more-display-number'}>{numberOfDrinks}</div>
+        <button className={'view-more-dropdown-button'} onClick={() => handleShowDropDown()}>
           <svg
             xmlns='http://www.w3.org/2000/svg'
             fill='none'
@@ -24,13 +24,13 @@ function ViewMoreDropDown(props) {
       </div>
       {showDropDown && (
         <div className='view-more-options-wrapper'>
-          <button id='button1' onClick={(e) => handleNumberChange(e)}>
+          <button className='view-more-options-button' onClick={(e) => handleNumberChange(e)}>
             10
           </button>
-          <button id='button2' onClick={(e) => handleNumberChange(e)}>
+          <button className='view-more-options-button' onClick={(e) => handleNumberChange(e)}>
             20
           </button>
-          <button id='button3' onClick={(e) => handleNumberChange(e)}>
+          <button className='view-more-options-button' onClick={(e) => handleNumberChange(e)}>
             30
           </button>
         </div>

--- a/src/components/ViewMoreDropDown/index.jsx
+++ b/src/components/ViewMoreDropDown/index.jsx
@@ -1,41 +1,65 @@
+
+import { ClickAwayListener } from '@mui/base';
+
 function ViewMoreDropDown(props) {
-  const {numberOfDrinks, handleNumberChange, handleShowDropDown, showDropDown} = props;
+  const {
+    numberOfDrinks,
+    handleNumberChange,
+    handleShowDropDown,
+    handleClickAway,
+    showDropDown,
+
+  } = props;
 
   return (
-    <div className='view-more-container'>
-      <div className='view-more-display-wrapper'>
-        <div className={'view-more-display-number'}>{numberOfDrinks}</div>
-        <button className={'view-more-dropdown-button'} onClick={() => handleShowDropDown()}>
-          <svg
-            xmlns='http://www.w3.org/2000/svg'
-            fill='none'
-            viewBox='0 0 24 24'
-            strokeWidth={1.5}
-            stroke='currentColor'
-            className='view-more-chevron-down'
+    <ClickAwayListener onClickAway={() => handleClickAway()}>
+      <div className='view-more-container'>
+        <div className='view-more-display-wrapper'>
+          <div className={'view-more-display-number'}>{numberOfDrinks}</div>
+          <button
+            className={'view-more-dropdown-button'}
+            onClick={() => handleShowDropDown()}
           >
-            <path
-              strokeLinecap='round'
-              strokeLinejoin='round'
-              d='m19.5 8.25-7.5 7.5-7.5-7.5'
-            />
-          </svg>
-        </button>
-      </div>
-      {showDropDown && (
-        <div className='view-more-options-wrapper'>
-          <button className='view-more-options-button' onClick={(e) => handleNumberChange(e)}>
-            10
-          </button>
-          <button className='view-more-options-button' onClick={(e) => handleNumberChange(e)}>
-            20
-          </button>
-          <button className='view-more-options-button' onClick={(e) => handleNumberChange(e)}>
-            30
+            <svg
+              xmlns='http://www.w3.org/2000/svg'
+              fill='none'
+              viewBox='0 0 24 24'
+              strokeWidth={1.5}
+              stroke='currentColor'
+              className='view-more-chevron-down'
+            >
+              <path
+                strokeLinecap='round'
+                strokeLinejoin='round'
+                d='m19.5 8.25-7.5 7.5-7.5-7.5'
+              />
+            </svg>
           </button>
         </div>
-      )}
-    </div>
+        {showDropDown && (
+          <div className='view-more-options-wrapper'>
+            <button
+              className='view-more-options-button'
+              onClick={(e) => handleNumberChange(e)}
+            >
+              10
+            </button>
+            <button
+              className='view-more-options-button'
+              onClick={(e) => handleNumberChange(e)}
+            >
+              20
+            </button>
+            <button
+              className='view-more-options-button'
+              onClick={(e) => handleNumberChange(e)}
+            >
+              30
+            </button>
+          </div>
+        )}
+      </div>
+    </ClickAwayListener>
   );
 }
 

--- a/src/components/ViewMoreDropDown/index.jsx
+++ b/src/components/ViewMoreDropDown/index.jsx
@@ -1,4 +1,3 @@
-
 import { ClickAwayListener } from '@mui/base';
 
 function ViewMoreDropDown(props) {
@@ -8,7 +7,6 @@ function ViewMoreDropDown(props) {
     handleShowDropDown,
     handleClickAway,
     showDropDown,
-
   } = props;
 
   return (

--- a/src/components/ViewMoreDropDown/index.jsx
+++ b/src/components/ViewMoreDropDown/index.jsx
@@ -1,28 +1,18 @@
-import { useState } from 'react';
+function ViewMoreDropDown(props) {
+  const {numberOfDrinks, handleNumberChange, handleShowDropDown, showDropDown} = props;
 
-function ViewMoreDropDown() {
-  const [option, setOption] = useState(10);
-  const [showDropDown, setShowDropDown] = useState(false);
-
-  const handleOptionChange = (e) => {
-    setOption(e.target.innerText);
-  };
-
-  const handleShowDropDown = () => {
-    setShowDropDown((prevState) => !prevState);
-  };
   return (
-    <div className='viewMore_Container'>
-      <div className='viewMore_displayWrapper'>
-        <div>{option}</div>
-        <button onClick={handleShowDropDown}>
+    <div className='view-more-container'>
+      <div className='view-more-display-wrapper'>
+        <div>{numberOfDrinks}</div>
+        <button onClick={() => handleShowDropDown()}>
           <svg
             xmlns='http://www.w3.org/2000/svg'
             fill='none'
             viewBox='0 0 24 24'
             strokeWidth={1.5}
             stroke='currentColor'
-            className='home-chevronDown'
+            className='view-more-chevron-down'
           >
             <path
               strokeLinecap='round'
@@ -32,17 +22,19 @@ function ViewMoreDropDown() {
           </svg>
         </button>
       </div>
-      <div className='viewMore_optionsWrapper'>
-        <button id='button1' onClick={handleOptionChange}>
-          10
-        </button>
-        <button id='button2' onClick={(e) => handleOptionChange(e)}>
-          20
-        </button>
-        <button id='button3' onClick={(e) => handleOptionChange(e)}>
-          30
-        </button>
-      </div>
+      {showDropDown && (
+        <div className='view-more-options-wrapper'>
+          <button id='button1' onClick={(e) => handleNumberChange(e)}>
+            10
+          </button>
+          <button id='button2' onClick={(e) => handleNumberChange(e)}>
+            20
+          </button>
+          <button id='button3' onClick={(e) => handleNumberChange(e)}>
+            30
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/ViewMoreDropDown/index.jsx
+++ b/src/components/ViewMoreDropDown/index.jsx
@@ -1,0 +1,48 @@
+import { useState } from 'react';
+
+function ViewMoreDropDown() {
+  const [option, setOption] = useState(10);
+  const [showDropDown, setShowDropDown] = useState(false);
+
+  const handleOptionChange = (e) => {
+    setOption(e.target.innerText);
+  };
+
+  const handleShowDropDown = () => {
+    setShowDropDown((prevState) => !prevState);
+  };
+  return (
+    <div>
+      <div>{option}</div>
+      <button onClick={handleShowDropDown}>
+        <svg
+          xmlns='http://www.w3.org/2000/svg'
+          fill='none'
+          viewBox='0 0 24 24'
+          strokeWidth={1.5}
+          stroke='currentColor'
+          className='home-chevronDown'
+        >
+          <path
+            strokeLinecap='round'
+            strokeLinejoin='round'
+            d='m19.5 8.25-7.5 7.5-7.5-7.5'
+          />
+        </svg>
+      </button>
+      <div>
+        <button id='button1' onClick={handleOptionChange}>
+          10
+        </button>
+        <button id='button2' onClick={(e) => handleOptionChange(e)}>
+          20
+        </button>
+        <button id='button3' onClick={(e) => handleOptionChange(e)}>
+          30
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default ViewMoreDropDown;

--- a/src/components/ViewMoreDropDown/index.jsx
+++ b/src/components/ViewMoreDropDown/index.jsx
@@ -12,25 +12,27 @@ function ViewMoreDropDown() {
     setShowDropDown((prevState) => !prevState);
   };
   return (
-    <div>
-      <div>{option}</div>
-      <button onClick={handleShowDropDown}>
-        <svg
-          xmlns='http://www.w3.org/2000/svg'
-          fill='none'
-          viewBox='0 0 24 24'
-          strokeWidth={1.5}
-          stroke='currentColor'
-          className='home-chevronDown'
-        >
-          <path
-            strokeLinecap='round'
-            strokeLinejoin='round'
-            d='m19.5 8.25-7.5 7.5-7.5-7.5'
-          />
-        </svg>
-      </button>
-      <div>
+    <div className='viewMore_Container'>
+      <div className='viewMore_displayWrapper'>
+        <div>{option}</div>
+        <button onClick={handleShowDropDown}>
+          <svg
+            xmlns='http://www.w3.org/2000/svg'
+            fill='none'
+            viewBox='0 0 24 24'
+            strokeWidth={1.5}
+            stroke='currentColor'
+            className='home-chevronDown'
+          >
+            <path
+              strokeLinecap='round'
+              strokeLinejoin='round'
+              d='m19.5 8.25-7.5 7.5-7.5-7.5'
+            />
+          </svg>
+        </button>
+      </div>
+      <div className='viewMore_optionsWrapper'>
         <button id='button1' onClick={handleOptionChange}>
           10
         </button>

--- a/src/index.css
+++ b/src/index.css
@@ -32,6 +32,10 @@ h2 {
   margin: 0;
 }
 
+h3 {
+  margin: 0;
+}
+
 .link {
   text-decoration: none;
 }

--- a/src/pages/Home/index.jsx
+++ b/src/pages/Home/index.jsx
@@ -21,6 +21,12 @@ function Home() {
     setShowDropDown((prevState) => !prevState);
   };
 
+  const handleClickAway = () => {
+    setShowDropDown((prevState) => !prevState);
+
+  }
+
+
   const fetchDefaultData = async () => {
     try {
       const { data } = await axios.get('https://api.punkapi.com/v2/beers');
@@ -93,6 +99,7 @@ function Home() {
             handleNumberChange={handleNumberChange}
             handleShowDropDown={handleShowDropDown}
             showDropDown={showDropDown}
+            handleClickAway={handleClickAway}
           />
         </span>
       </p>

--- a/src/pages/Home/index.jsx
+++ b/src/pages/Home/index.jsx
@@ -21,7 +21,6 @@ function Home() {
     setShowDropDown((prevState) => !prevState);
   };
 
-
   const fetchDefaultData = async () => {
     try {
       const { data } = await axios.get('https://api.punkapi.com/v2/beers');
@@ -84,13 +83,20 @@ function Home() {
 
   return (
     <div className={'home_Container'}>
-      <h2 className={'home_Title'}>Punk Drinks</h2>
-      <ViewMoreDropDown
-        numberOfDrinks={numberOfDrinks}
-        handleNumberChange={handleNumberChange}
-        handleShowDropDown={handleShowDropDown}
-        showDropDown={showDropDown}
-      />
+      <h2 className={'home_Title'}>BrewDog</h2>
+      <h3 className={'home-tagline'}>Something for everyone</h3>
+      <p className={'home-dropdown-container'}>
+        Drinks Per Page
+        <span className={'home-dropdown-text-span'}>
+          <ViewMoreDropDown
+            numberOfDrinks={numberOfDrinks}
+            handleNumberChange={handleNumberChange}
+            handleShowDropDown={handleShowDropDown}
+            showDropDown={showDropDown}
+          />
+        </span>
+      </p>
+
       <ul className={'home_drinksContainer'}>
         {drinksList.map((drink) => (
           <Link className='link' key={drink.id} to={`drink/${drink.id}`}>

--- a/src/pages/Home/index.jsx
+++ b/src/pages/Home/index.jsx
@@ -7,21 +7,67 @@ import ViewMoreDropDown from '../../components/ViewMoreDropDown';
 import { Link } from 'react-router-dom';
 
 function Home() {
-  const [drinkList, setDrinkList] = useState([]);
+  const [drinksList, setDrinksList] = useState([]);
+  const [numberOfDrinks, setNumberOfDrinks] = useState(10);
+  const [showDropDown, setShowDropDown] = useState(false);
 
-  const fetchDrinkData = async () => {
+  const handleShowDropDown = () => {
+    setShowDropDown((prevState) => !prevState);
+  };
+
+  const handleNumberChange = (e) => {
+    const parseDrinksNumber = parseInt(e.target.innerText);
+    setNumberOfDrinks(parseDrinksNumber);
+    setShowDropDown((prevState) => !prevState);
+  };
+
+
+  const fetchDefaultData = async () => {
     try {
       const { data } = await axios.get('https://api.punkapi.com/v2/beers');
-      const drinkList = createDrinkList(data);
-      setDrinkList(drinkList);
+      return data;
     } catch (error) {
       console.error(error);
     }
   };
 
-  const createDrinkList = (data) => {
-    const drinksRequired = data.slice(0, 10);
-    return drinksRequired.map((drink) => {
+  const fetchLargeData = async () => {
+    try {
+      const { data } = await axios.get(
+        'https://api.punkapi.com/v2/beers?per_page=30'
+      );
+      return data;
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  const fetchRequiredDrinks = async (numberOfDrinks) => {
+    let data = [];
+    if (numberOfDrinks === 10 || numberOfDrinks === 20) {
+      data = await fetchDefaultData();
+    }
+    if (numberOfDrinks === 30) {
+      data = await fetchLargeData();
+    }
+    createDrinksList(data);
+  };
+
+  const trimDrinkData = (data) => {
+    let trimmedData = [];
+    if (numberOfDrinks === 10) {
+      trimmedData = data.slice(0, 10);
+    } else if (numberOfDrinks === 20) {
+      trimmedData = data.slice(0, 20);
+    } else if (numberOfDrinks === 30) {
+      trimmedData = data;
+    }
+    return trimmedData;
+  };
+
+  const createDrinksList = (data) => {
+    const drinksRequired = trimDrinkData(data);
+    const drinksList = drinksRequired.map((drink) => {
       return {
         id: drink.id,
         imageUrl: drink.image_url,
@@ -29,22 +75,28 @@ function Home() {
         description: drink.description,
       };
     });
+    setDrinksList(drinksList);
   };
 
   useEffect(() => {
-    fetchDrinkData();
-  }, []);
+    fetchRequiredDrinks(numberOfDrinks);
+  }, [numberOfDrinks]);
 
   return (
     <div className={'home_Container'}>
       <h2 className={'home_Title'}>Punk Drinks</h2>
-      <ViewMoreDropDown />
+      <ViewMoreDropDown
+        numberOfDrinks={numberOfDrinks}
+        handleNumberChange={handleNumberChange}
+        handleShowDropDown={handleShowDropDown}
+        showDropDown={showDropDown}
+      />
       <ul className={'home_drinksContainer'}>
-        {drinkList.map((drink) => (
+        {drinksList.map((drink) => (
           <Link className='link' key={drink.id} to={`drink/${drink.id}`}>
             <li className='home_drinkListItem'>
               <div className={'home_drinkDisplayWrapper'}>
-                <DisplayDrink drink={drink}  location={'Home'} />
+                <DisplayDrink drink={drink} location={'Home'} />
                 <DisplayText drink={drink} location={'Home'} />
               </div>
             </li>

--- a/src/pages/Home/index.jsx
+++ b/src/pages/Home/index.jsx
@@ -2,6 +2,8 @@ import { useEffect, useState } from 'react';
 import axios from 'axios';
 import DisplayDrink from '../../components/DisplayDrink';
 import DisplayText from '../../components/DisplayText';
+import ViewMoreDropDown from '../../components/ViewMoreDropDown';
+
 import { Link } from 'react-router-dom';
 
 function Home() {
@@ -36,6 +38,7 @@ function Home() {
   return (
     <div className={'home_Container'}>
       <h2 className={'home_Title'}>Punk Drinks</h2>
+      <ViewMoreDropDown />
       <ul className={'home_drinksContainer'}>
         {drinkList.map((drink) => (
           <Link className='link' key={drink.id} to={`drink/${drink.id}`}>


### PR DESCRIPTION
Set up a dropdown for the user to choose the number of drinks visible.
Options are given of 10, 20 and 30 drinks. Multiples of 5 for maintaining the display - 5 drinks per line
Default fetch data returns 25 drinks. An additional fetch data API was created to return 30 drinks.
The state was lifted to the Home page from the Dropdown component. This means the correct APIs can be requested.
Title change and more text added so dropdown could be positioned correctly
Dropdown styled.
Additional styling for the drinks selection. A coloured border shows on hover to improve UX.