### PR TITLE
wrapper around Drink page contents to position top center

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -87,20 +87,24 @@
   margin-left: 5px;
 }
 
-.drink-drink-container {
+.drink-wrapper {
+  height: 100vh;
+  height: 100vw;
   display: flex;
   flex-direction: column;
+  justify-content: start;
   align-items: center;
   text-align: center;
+  margin-top: 40px;
   padding-top: 40px;
-  width: fit-content;
 }
 
-.drink-drink-wrapper {
-  height: fit-content;
+.drink-container {
   padding: 40px 20px;
+  margin-bottom: 40px;
   background-color: #f5f5f5;
   border-radius: 30px;
+
 }
 
 .drink-text-wrapper {

--- a/src/pages/Drink/index.jsx
+++ b/src/pages/Drink/index.jsx
@@ -57,8 +57,8 @@ function Drink() {
     <>
       {isLoading && <LoadingSpinner />}
       {!isLoading && (
-        <div className={'drink-drink-container'}>
-          <div className={'drink-drink-wrapper'}>
+        <div className={'drink-wrapper'}>
+          <div className={'drink-container'}>
             <DrinkImage drinkData={drinkData} location={'Drink'} />
             <DrinkText drinkData={drinkData} location={'Drink'} />
             <NavButton />


### PR DESCRIPTION
The drinks page was not being positioned correctly on a larger screen.
Names for the container class and wrapper class were switched so the wrapper was on the outside.
CSS styling of the wrapper to set the position of the page to be top and centre.
Improved naming of the two CSS classes for readability.