### PR TITLE
Set loading spinner when drink numbers change

### DIFF
--- a/src/components/LoadingSpinner/LoadingSpinner.css
+++ b/src/components/LoadingSpinner/LoadingSpinner.css
@@ -6,9 +6,20 @@
       transform: rotate(360deg);
     }
   }
+
+  .spinner-container {
+    width: 100vw;
+    height: 100vh;
+    position: relative;
+    display: flex;
+    justify-content: center;
+  }
+
   .loading-spinner {
     width: 50px;
     height: 50px;
+    position: absolute;
+    top: 400px;
     border: 10px solid #f5f5f5;
     border-top: 10px solid #383636;
     border-radius: 50%;

--- a/src/components/LoadingSpinner/index.jsx
+++ b/src/components/LoadingSpinner/index.jsx
@@ -1,12 +1,11 @@
-import "./LoadingSpinner.css"
+import './LoadingSpinner.css';
 
 function LoadingSpinner() {
   return (
-    <div className="spinner-container">
-      <div className="loading-spinner">
-      </div>
+    <div className='spinner-container'>
+      <div className='loading-spinner'></div>
     </div>
   );
-};
+}
 
 export default LoadingSpinner;

--- a/src/pages/Home/index.jsx
+++ b/src/pages/Home/index.jsx
@@ -26,6 +26,10 @@ function Home() {
     setShowDropdown((prevState) => !prevState);
   };
 
+  const hasData = () => {
+    return drinksList.length > 0;
+  };
+
   const fetchDefaultData = async () => {
     try {
       const { data } = await axios.get('https://api.punkapi.com/v2/beers');
@@ -47,6 +51,7 @@ function Home() {
   };
 
   const fetchRequiredDrinks = async (numberOfDrinks) => {
+    if (hasData) setIsLoading(true);
     let data = [];
     if (numberOfDrinks === 10 || numberOfDrinks === 20) {
       data = await fetchDefaultData();


### PR DESCRIPTION
The loading spinner was not visible when the user altered the number of drinks to view.
A check for existing data means setLoading is not changed unnecessarily.
It only needs to be set to true if the data already exists. Its default state is true for the first render.