### PR TITLE
amended handleClickaway function

### DIFF
--- a/src/pages/Home/index.jsx
+++ b/src/pages/Home/index.jsx
@@ -23,7 +23,7 @@ function Home() {
   };
 
   const handleClickAway = () => {
-    setShowDropdown((setShowDropdown) => !setShowDropdown);
+    setShowDropdown(false);
   };
 
   const hasData = () => {


### PR DESCRIPTION
When clicking anywhere outside of the dropdown, the dropdown appeared.

The handleClickAway function was changed. It was toggling the boolean for the state showDropdown. It only sets the boolean to false. This prevents the dropdown opening by accident.