### PR TITLE
Setup session storage for number of drinks viewed

### DIFF
--- a/src/components/DropdownMenu/index.jsx
+++ b/src/components/DropdownMenu/index.jsx
@@ -1,14 +1,23 @@
 import { ClickAwayListener } from '@mui/base';
 import './DropdownMenu.css';
+import { useEffect } from 'react';
 
 function DropdownMenu(props) {
   const {
     numberOfDrinks,
+    setNumberOfDrinks,
     handleNumberChange,
     handleShowDropdown,
     handleClickAway,
     showDropdown,
   } = props;
+
+  useEffect(() => {
+    const storedNumberOfDrinks = sessionStorage.getItem('numberOfDrinks');
+    if (storedNumberOfDrinks) {
+      setNumberOfDrinks(parseInt(storedNumberOfDrinks));
+    }
+  }, [])
 
   return (
     <ClickAwayListener onClickAway={handleClickAway}>

--- a/src/components/DropdownMenu/index.jsx
+++ b/src/components/DropdownMenu/index.jsx
@@ -17,7 +17,7 @@ function DropdownMenu(props) {
     if (storedNumberOfDrinks) {
       setNumberOfDrinks(parseInt(storedNumberOfDrinks));
     }
-  }, [])
+  }, []);
 
   return (
     <ClickAwayListener onClickAway={handleClickAway}>

--- a/src/components/DropdownMenu/index.jsx
+++ b/src/components/DropdownMenu/index.jsx
@@ -15,7 +15,8 @@ function DropdownMenu(props) {
   useEffect(() => {
     const storedNumberOfDrinks = sessionStorage.getItem('numberOfDrinks');
     if (storedNumberOfDrinks) {
-      setNumberOfDrinks(parseInt(storedNumberOfDrinks));
+      const parsedNumber = parseInt(storedNumberOfDrinks);
+      setNumberOfDrinks(parsedNumber);
     }
   }, []);
 

--- a/src/pages/Home/index.jsx
+++ b/src/pages/Home/index.jsx
@@ -19,6 +19,7 @@ function Home() {
   const handleNumberChange = (e) => {
     const parsedDrinksNumber = parseInt(e.target.innerText);
     setNumberOfDrinks(parsedDrinksNumber);
+    sessionStorage.setItem('numberOfDrinks', parsedDrinksNumber);
     setShowDropdown((setShowDropdown) => !setShowDropdown);
   };
 
@@ -50,33 +51,33 @@ function Home() {
     }
   };
 
-  const fetchRequiredDrinks = async () => {
+  const fetchRequiredDrinks = async (number) => {
     if (hasData()) setIsLoading(true);
     let data = [];
-    if (numberOfDrinks === 10 || numberOfDrinks === 20) {
+    if (number === 10 || number === 20) {
       data = await fetchDefaultData();
     }
-    if (numberOfDrinks === 30) {
+    if (number === 30) {
       data = await fetchLargeData();
     }
-    createDrinksList(data);
+    createDrinksList(data, number);
     setIsLoading(false);
   };
 
-  const trimDrinkData = (data) => {
+  const trimDrinkData = (data, number)=> {
     let trimmedData = [];
-    if (numberOfDrinks === 10) {
+    if (number === 10) {
       trimmedData = data.slice(0, 10);
-    } else if (numberOfDrinks === 20) {
+    } else if (number === 20) {
       trimmedData = data.slice(0, 20);
-    } else if (numberOfDrinks === 30) {
+    } else if (number === 30) {
       trimmedData = data;
     }
     return trimmedData;
   };
 
-  const createDrinksList = (data) => {
-    const drinksRequired = trimDrinkData(data);
+  const createDrinksList = (data, number) => {
+    const drinksRequired = trimDrinkData(data, number);
     const drinksList = drinksRequired.map((drink) => {
       return {
         id: drink.id,
@@ -89,7 +90,15 @@ function Home() {
   };
 
   useEffect(() => {
-    fetchRequiredDrinks(numberOfDrinks);
+    const sessionNumberOfDrinks = sessionStorage.getItem('numberOfDrinks');
+    console.log(sessionNumberOfDrinks, "session no");
+    if (sessionNumberOfDrinks) {
+      const parsedNumber = parseInt(sessionNumberOfDrinks);
+      console.log(parsedNumber, "parsed no");
+      fetchRequiredDrinks(parsedNumber);
+    } else {
+      fetchRequiredDrinks(numberOfDrinks);
+    }
   }, [numberOfDrinks]);
 
   return (

--- a/src/pages/Home/index.jsx
+++ b/src/pages/Home/index.jsx
@@ -64,7 +64,7 @@ function Home() {
     setIsLoading(false);
   };
 
-  const trimDrinkData = (data, drinksNumber)=> {
+  const trimDrinkData = (data, drinksNumber) => {
     let trimmedData = [];
     if (drinksNumber === 10) {
       trimmedData = data.slice(0, 10);

--- a/src/pages/Home/index.jsx
+++ b/src/pages/Home/index.jsx
@@ -112,6 +112,7 @@ function Home() {
               <span className='home-dropdown-text-span'>
                 <Dropdown
                   numberOfDrinks={numberOfDrinks}
+                  setNumberOfDrinks={setNumberOfDrinks}
                   handleNumberChange={handleNumberChange}
                   handleShowDropdown={handleShowDropdown}
                   showDropdown={showDropdown}

--- a/src/pages/Home/index.jsx
+++ b/src/pages/Home/index.jsx
@@ -91,10 +91,8 @@ function Home() {
 
   useEffect(() => {
     const sessionNumberOfDrinks = sessionStorage.getItem('numberOfDrinks');
-    console.log(sessionNumberOfDrinks, "session no");
     if (sessionNumberOfDrinks) {
       const parsedNumber = parseInt(sessionNumberOfDrinks);
-      console.log(parsedNumber, "parsed no");
       fetchRequiredDrinks(parsedNumber);
     } else {
       fetchRequiredDrinks(numberOfDrinks);

--- a/src/pages/Home/index.jsx
+++ b/src/pages/Home/index.jsx
@@ -51,33 +51,33 @@ function Home() {
     }
   };
 
-  const fetchRequiredDrinks = async (number) => {
+  const fetchRequiredDrinks = async (drinksNumber) => {
     if (hasData()) setIsLoading(true);
     let data = [];
-    if (number === 10 || number === 20) {
+    if (drinksNumber === 10 || drinksNumber === 20) {
       data = await fetchDefaultData();
     }
-    if (number === 30) {
+    if (drinksNumber === 30) {
       data = await fetchLargeData();
     }
-    createDrinksList(data, number);
+    createDrinksList(data, drinksNumber);
     setIsLoading(false);
   };
 
-  const trimDrinkData = (data, number)=> {
+  const trimDrinkData = (data, drinksNumber)=> {
     let trimmedData = [];
-    if (number === 10) {
+    if (drinksNumber === 10) {
       trimmedData = data.slice(0, 10);
-    } else if (number === 20) {
+    } else if (drinksNumber === 20) {
       trimmedData = data.slice(0, 20);
-    } else if (number === 30) {
+    } else if (drinksNumber === 30) {
       trimmedData = data;
     }
     return trimmedData;
   };
 
-  const createDrinksList = (data, number) => {
-    const drinksRequired = trimDrinkData(data, number);
+  const createDrinksList = (data, drinksNumber) => {
+    const drinksRequired = trimDrinkData(data, drinksNumber);
     const drinksList = drinksRequired.map((drink) => {
       return {
         id: drink.id,


### PR DESCRIPTION
When navigating back to the home page the number of drinks reverted to the default, 10.

To improve UX session storage was set up. This enables the number of drinks selected by the user to re-appear.

The display in the dropdown reads the session storage so it shows the correct number.